### PR TITLE
C++ header file for constants

### DIFF
--- a/xibetagenomiconstants.hpp
+++ b/xibetagenomiconstants.hpp
@@ -1,0 +1,10 @@
+/* use with  xibetagenomic.cpp */
+extern const unsigned samplesize ;
+extern const unsigned lgroups ;
+extern const unsigned Imin ;
+extern const unsigned Imax ;
+extern const unsigned Jmin ;
+extern const unsigned Jmax ;
+extern const unsigned Kmin ;
+extern const unsigned Kmax ;
+extern const unsigned trials ;


### PR DESCRIPTION
defines constants for  computing  summary statistics  of  genomic site-frequency spectrum, i.e.  a set of site-frequency spectra 
from  unlinked loci - include with  xibetagenomicpython.cpp